### PR TITLE
Add inclusive naming action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,8 +1,8 @@
-name: master checks
+name: main checks
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   SECRET_KEY: insecure_test_key

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,3 +90,16 @@ jobs:
           coverage run  --source=. -m unittest discover tests
           bash <(curl -s https://codecov.io/bash) -cF python
 
+  check-inclusive-naming:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check inclusive naming
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          fail-on-error: true

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![pythonoperatorframework.io](https://user-images.githubusercontent.com/6353928/94026467-9dff1480-fdb1-11ea-8026-e866246815fc.png "The Python Operator Framework")
 # pythonoperatorframework.io
 
-![Github Actions Status](https://github.com/canonical-web-and-design/pythonoperatorframework.io/workflows/master%20checks/badge.svg) [![Code coverage](https://codecov.io/gh/canonical-web-and-design/pythonoperatorframework.io/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/pythonoperatorframework.io)
+![Github Actions Status](https://github.com/canonical-web-and-design/pythonoperatorframework.io/workflows/main%20checks/badge.svg) [![Code coverage](https://codecov.io/gh/canonical-web-and-design/pythonoperatorframework.io/branch/main/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/pythonoperatorframework.io)
 
 The Python Operator Framework provides a simple, lightweight, and powerful way of writing Juju charms, the best way to encapsulate operational experience in code.
 


### PR DESCRIPTION
## Done
- _Adds inclusive naming github action_
- _Replaces key non-inclusive language_

**TODO**: Rename 'master' to 'main'

## How to QA
- Visit the demo in your browser, link commented below
  - Or you can run the project locally using the [dotrun](https://snapcraft.io/dotrun) snap with `$ dotrun` and view it in your web browser at: http://0.0.0.0:8047/
  - If your demo doesn't work, read more about the [demoservice](https://discourse.ubuntu.com/t/demoservice/16862)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check github action works
- Check language changes make lexical sense

## Issue / Card
Fixes https://app.zenhub.com/workspaces/-web-squad-5931746dba512f05402b61f6/issues/canonical-web-and-design/web-squad/4478
